### PR TITLE
Don't use Valve file system when calling a FileExists.

### DIFF
--- a/src/zr/downloads.inc
+++ b/src/zr/downloads.inc
@@ -75,7 +75,7 @@ DownloadsLoad()
         GetArrayString(arrayDownloads, x, downloadpath, sizeof(downloadpath));
 
         // If file doesn't exist, then remove, log, and stop.
-        if (!FileExists(downloadpath, true))
+        if (!FileExists(downloadpath, false))
         {
             // Remove client from array.
             RemoveFromArray(arrayDownloads, x);

--- a/src/zr/models.inc
+++ b/src/zr/models.inc
@@ -125,7 +125,7 @@ ModelsLoad()
         strcopy(buffer, sizeof(buffer), path);
         StrCat(buffer, sizeof(buffer), name);
         StrCat(buffer, sizeof(buffer), ".mdl");
-        if (!FileExists(buffer, true))
+        if (!FileExists(buffer, false))
         {
             LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "Warning: Invalid model name/path setting at index %d. File not found: \"%s\".", ModelCount + failedCount, buffer);
             failedCount++;

--- a/src/zr/playerclasses/filtertools.inc
+++ b/src/zr/playerclasses/filtertools.inc
@@ -202,7 +202,7 @@ stock ClassValidateAttributes(classindex, bool:logErrors = false)
             !StrEqual(model_path, "no_change", false))
         {
             // Check if the file exists.
-            if (!FileExists(model_path, true))
+            if (!FileExists(model_path, false))
             {
                 flags += ZR_CLASS_MODEL_PATH;
                 if (logErrors)
@@ -264,7 +264,7 @@ stock ClassValidateAttributes(classindex, bool:logErrors = false)
     {
         // Check if the file exists.
         Format(overlay, sizeof(overlay), "materials/%s.vmt", overlay_path);
-        if (!FileExists(overlay, true))
+        if (!FileExists(overlay, false))
         {
             flags += ZR_CLASS_OVERLAY_PATH;
             if (logErrors)
@@ -503,7 +503,7 @@ stock ClassValidateEditableAttributes(attributes[ClassEditableAttributes])
         {
             // Check if the file exists.
             Format(overlay, sizeof(overlay), "materials/%s.vmt", overlay_path);
-            if (!FileExists(overlay, true))
+            if (!FileExists(overlay, false))
             {
                 flags += ZR_CLASS_OVERLAY_PATH;
             }

--- a/src/zr/soundeffects/ambientsounds.inc
+++ b/src/zr/soundeffects/ambientsounds.inc
@@ -79,7 +79,7 @@ bool:AmbientSoundsValidateConfig()
     Format(sound, sizeof(sound), "sound/%s", sound);
 
     // If file doesn't exist, then log error and stop.
-    if (!FileExists(sound, true))
+    if (!FileExists(sound, false))
     {
         // Log invalid sound file error.
         LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_SEffects, "Config Validation", "Invalid sound file specified in \"zr_ambientsounds_file\": %s", sound);


### PR DESCRIPTION
The problem is that you can't use models,materials and sounds in a Z:R if their path contains an upper case letters (Linux tested, Windows not).

More information about this problem can be found here: https://bugs.alliedmods.net/show_bug.cgi?id=6406