### PR TITLE
Fixed Russian translation

### DIFF
--- a/cstrike/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
+++ b/cstrike/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
@@ -716,7 +716,7 @@
 
 	"Weapons menu zmarket loadout default"
 	{
-		"ru"		"{1} (текущее)"
+		"ru"		"{1} (по умолчанию)"
 	}
 
 	"Weapons menu zmarket loadout weapons title"


### PR DESCRIPTION
Fixed "Weapons menu zmarket loadout default" phrase in Russian translation.